### PR TITLE
feat: Overpass OSM extractor for Florianópolis hospitality POIs

### DIFF
--- a/src/extractors/overpass_osm.py
+++ b/src/extractors/overpass_osm.py
@@ -1,0 +1,390 @@
+"""
+Overpass OSM Extractor
+======================
+Extracts Points of Interest (POIs) for hospitality establishments in
+Florianópolis from OpenStreetMap via the Overpass API.
+
+Categories extracted:
+    - tourism: hotel, hostel, guest_house
+    - amenity: restaurant, cafe, bar, pub
+
+Bounding box: (-27.85, -48.65, -27.38, -48.33)  # (south, west, north, east)
+
+Usage:
+    python -m src.extractors.overpass_osm
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from src.config.settings import get_settings
+from src.config.supabase_client import get_supabase_client
+from src.models.estabelecimento import RawEstablishment
+from src.utils.logger import get_logger
+from src.utils.retry import with_retry
+
+logger = get_logger(__name__)
+
+# Florianópolis bounding box: (south, west, north, east)
+FLORIANOPOLIS_BBOX: tuple[float, float, float, float] = (-27.85, -48.65, -27.38, -48.33)
+
+# Queries to execute: (key, value) pairs
+OVERPASS_QUERIES: list[dict[str, str]] = [
+    {"key": "tourism", "value": "hotel"},
+    {"key": "tourism", "value": "hostel"},
+    {"key": "tourism", "value": "guest_house"},
+    {"key": "amenity", "value": "restaurant"},
+    {"key": "amenity", "value": "cafe"},
+    {"key": "amenity", "value": "bar"},
+    {"key": "amenity", "value": "pub"},
+]
+
+# Rate limiting: max 2 concurrent requests, 10s cooldown between sequential queries
+_RATE_LIMIT_SEMAPHORE = threading.Semaphore(2)
+_RATE_LIMIT_COOLDOWN = 10.0  # seconds between queries
+
+_HTTP_TIMEOUT = 60.0  # seconds
+
+
+def _build_overpass_query(
+    key: str,
+    value: str,
+    bbox: tuple[float, float, float, float],
+) -> str:
+    """
+    Build an Overpass QL query for nodes and ways matching the given tag.
+
+    Args:
+        key: OSM tag key (e.g. 'tourism', 'amenity').
+        value: OSM tag value (e.g. 'hotel', 'restaurant').
+        bbox: Bounding box as (south, west, north, east).
+
+    Returns:
+        Overpass QL query string.
+    """
+    south, west, north, east = bbox
+    bbox_str = f"{south},{west},{north},{east}"
+    return (
+        f"[out:json][timeout:30];\n"
+        f"(\n"
+        f"  node[{key}={value}]({bbox_str});\n"
+        f"  way[{key}={value}]({bbox_str});\n"
+        f");\n"
+        f"out center tags;"
+    )
+
+
+@with_retry(
+    max_attempts=3,
+    base_delay=2.0,
+    retryable_exceptions=(ConnectionError, TimeoutError, OSError),
+)
+def _fetch_overpass(query: str, api_url: str) -> dict[str, Any]:
+    """
+    Execute an Overpass QL query via HTTP POST.
+
+    Handles 429 rate-limit responses by raising a ConnectionError so the
+    with_retry decorator backs off and retries automatically.
+
+    Args:
+        query: Overpass QL query string.
+        api_url: Overpass API endpoint URL.
+
+    Returns:
+        Parsed JSON response from the Overpass API.
+
+    Raises:
+        ConnectionError: On network errors or 429 / unexpected status responses.
+    """
+    with _RATE_LIMIT_SEMAPHORE:
+        try:
+            response = httpx.post(
+                api_url,
+                data={"data": query},
+                timeout=_HTTP_TIMEOUT,
+            )
+        except (httpx.TimeoutException, httpx.NetworkError) as exc:
+            raise ConnectionError(f"Overpass API request failed: {exc}") from exc
+
+    if response.status_code == 429:
+        raise ConnectionError("Overpass API rate limit exceeded (429). Backing off.")
+
+    if response.status_code != 200:
+        raise ConnectionError(
+            f"Overpass API returned status {response.status_code}: {response.text[:200]}"
+        )
+
+    try:
+        return response.json()  # type: ignore[no-any-return]
+    except Exception as exc:
+        raise ConnectionError(
+            f"Failed to parse Overpass API response as JSON: {exc}"
+        ) from exc
+
+
+def _parse_element(
+    element: dict[str, Any],
+    key: str,
+    value: str,
+) -> RawEstablishment | None:
+    """
+    Convert a single Overpass API element into a RawEstablishment.
+
+    Handles both node elements (lat/lon directly on the element) and
+    way elements (lat/lon inside a 'center' sub-object).
+
+    Args:
+        element: A single OSM element dict from the Overpass API response.
+        key: OSM tag key used in the query (e.g. 'tourism').
+        value: OSM tag value used in the query (e.g. 'hotel').
+
+    Returns:
+        A validated RawEstablishment instance, or None if the element is
+        missing coordinates or fails validation.
+    """
+    tags: dict[str, str] = element.get("tags", {})
+    element_type: str = element.get("type", "node")
+    element_id: int = element.get("id", 0)
+
+    # Ways use a 'center' sub-object for their representative coordinate
+    if element_type == "node":
+        lat = element.get("lat")
+        lon = element.get("lon")
+    else:
+        center = element.get("center", {})
+        lat = center.get("lat")
+        lon = center.get("lon")
+
+    if lat is None or lon is None:
+        logger.warning(
+            "overpass_element_missing_coords",
+            element_id=element_id,
+            element_type=element_type,
+        )
+        return None
+
+    # Build a composite address from addr:* tags
+    addr_parts = [
+        tags.get("addr:street", ""),
+        tags.get("addr:housenumber", ""),
+        tags.get("addr:city", ""),
+    ]
+    address = ", ".join(p for p in addr_parts if p) or None
+
+    # Anything not in the standard schema goes to extra_data
+    standard_keys = {
+        "name", "phone", "contact:phone", "website", "contact:website",
+        "opening_hours", "cuisine", "addr:street", "addr:housenumber",
+        "addr:city", key,
+    }
+    extra: dict[str, Any] = {k: v for k, v in tags.items() if k not in standard_keys}
+
+    try:
+        return RawEstablishment(
+            source="overpass",
+            source_id=f"{element_type}/{element_id}",
+            name=tags.get("name"),
+            latitude=float(lat),
+            longitude=float(lon),
+            raw_type=f"{key}={value}",
+            phone=tags.get("phone") or tags.get("contact:phone"),
+            website=tags.get("website") or tags.get("contact:website"),
+            opening_hours=tags.get("opening_hours"),
+            cuisine=tags.get("cuisine"),
+            address=address,
+            extra_data=extra or None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "overpass_element_validation_failed",
+            element_id=element_id,
+            error=str(exc),
+        )
+        return None
+
+
+def _insert_batch(records: list[RawEstablishment], batch_id: str) -> int:
+    """
+    Upsert validated records into raw_crawled_data.
+
+    Uses ON CONFLICT DO NOTHING on (source, source_id) so re-running the
+    extractor never creates duplicate rows.
+
+    Args:
+        records: Validated RawEstablishment instances to persist.
+        batch_id: UUID string grouping all records from this pipeline run.
+
+    Returns:
+        Number of rows actually inserted.
+    """
+    if not records:
+        return 0
+
+    client = get_supabase_client()
+
+    rows = [
+        {
+            "source": r.source,
+            "source_id": r.source_id,
+            "payload": r.model_dump(mode="json"),
+            "batch_id": batch_id,
+        }
+        for r in records
+    ]
+
+    result = (
+        client.table("raw_crawled_data")
+        .upsert(rows, on_conflict="source,source_id", ignore_duplicates=True)
+        .execute()
+    )
+
+    inserted = len(result.data) if result.data else 0
+    logger.info("overpass_batch_inserted", count=inserted, batch_id=batch_id)
+    return inserted
+
+
+def _log_pipeline(
+    batch_id: str,
+    status: str,
+    records_processed: int = 0,
+    error_message: str | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+) -> None:
+    """
+    Write a pipeline execution record to data_pipeline_logs.
+
+    Failures are swallowed so that audit log errors never crash the extractor.
+    """
+    try:
+        client = get_supabase_client()
+        row: dict[str, Any] = {
+            "pipeline_name": "overpass_osm_extractor",
+            "batch_id": batch_id,
+            "status": status,
+            "records_processed": records_processed,
+            "github_run_id": os.getenv("GITHUB_RUN_ID"),
+            "github_workflow": os.getenv("GITHUB_WORKFLOW"),
+        }
+        if error_message is not None:
+            row["error_message"] = error_message
+        if started_at is not None:
+            row["started_at"] = started_at.isoformat()
+        if finished_at is not None:
+            row["finished_at"] = finished_at.isoformat()
+            if started_at is not None:
+                row["duration_ms"] = int((finished_at - started_at).total_seconds() * 1000)
+
+        client.table("data_pipeline_logs").insert(row).execute()
+    except Exception as exc:
+        logger.error("pipeline_log_write_failed", error=str(exc))
+
+
+def run_extraction() -> int:
+    """
+    Run the full Overpass OSM extraction pipeline.
+
+    For each configured query:
+        1. Build the Overpass QL query for the bounding box.
+        2. Fetch POIs from the Overpass API (with retry on transient errors).
+        3. Parse and validate each OSM element with RawEstablishment.
+        4. Upsert valid records into raw_crawled_data under a shared batch_id.
+
+    A 10-second cooldown is applied between consecutive API requests.
+    Pipeline start/finish/error events are recorded in data_pipeline_logs.
+
+    Returns:
+        Total number of records inserted across all queries.
+    """
+    settings = get_settings()
+    api_url = settings.OVERPASS_API_URL
+    batch_id = str(uuid.uuid4())
+    started_at = datetime.now(tz=timezone.utc)
+
+    _log_pipeline(batch_id=batch_id, status="running", started_at=started_at)
+    logger.info("extraction_started", pipeline="overpass_osm", batch_id=batch_id)
+
+    total_inserted = 0
+    total_parsed = 0
+
+    try:
+        for i, query_config in enumerate(OVERPASS_QUERIES):
+            if i > 0:
+                time.sleep(_RATE_LIMIT_COOLDOWN)
+
+            key = query_config["key"]
+            value = query_config["value"]
+            raw_type = f"{key}={value}"
+
+            logger.info("fetching_overpass_query", raw_type=raw_type)
+
+            query = _build_overpass_query(key, value, FLORIANOPOLIS_BBOX)
+            data = _fetch_overpass(query, api_url)
+
+            elements: list[dict[str, Any]] = data.get("elements", [])
+            logger.info(
+                "overpass_elements_received",
+                raw_type=raw_type,
+                element_count=len(elements),
+            )
+
+            records: list[RawEstablishment] = []
+            for element in elements:
+                record = _parse_element(element, key, value)
+                if record is not None:
+                    records.append(record)
+
+            inserted = _insert_batch(records, batch_id)
+            total_inserted += inserted
+            total_parsed += len(records)
+
+            logger.info(
+                "overpass_query_complete",
+                raw_type=raw_type,
+                records_parsed=len(records),
+                records_inserted=inserted,
+            )
+
+    except Exception as exc:
+        finished_at = datetime.now(tz=timezone.utc)
+        logger.error("extraction_failed", error=str(exc), error_type=type(exc).__name__)
+        _log_pipeline(
+            batch_id=batch_id,
+            status="error",
+            records_processed=total_inserted,
+            error_message=str(exc),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        raise
+
+    finished_at = datetime.now(tz=timezone.utc)
+    _log_pipeline(
+        batch_id=batch_id,
+        status="success",
+        records_processed=total_inserted,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    logger.info(
+        "extraction_complete",
+        pipeline="overpass_osm",
+        total_parsed=total_parsed,
+        total_inserted=total_inserted,
+        duration_ms=int((finished_at - started_at).total_seconds() * 1000),
+    )
+
+    return total_inserted
+
+
+if __name__ == "__main__":
+    total = run_extraction()
+    print(f"Extracted {total} records from Overpass OSM.")

--- a/tests/test_extractors/test_overpass_osm.py
+++ b/tests/test_extractors/test_overpass_osm.py
@@ -1,0 +1,530 @@
+"""
+Unit tests for the Overpass OSM extractor.
+
+All external dependencies (httpx, Supabase, settings) are mocked so
+these tests run fully offline without any real credentials or network.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.extractors.overpass_osm import (
+    FLORIANOPOLIS_BBOX,
+    OVERPASS_QUERIES,
+    _build_overpass_query,
+    _fetch_overpass,
+    _insert_batch,
+    _log_pipeline,
+    _parse_element,
+    run_extraction,
+)
+from src.models.estabelecimento import RawEstablishment
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_node(
+    node_id: int = 1,
+    lat: float = -27.5,
+    lon: float = -48.5,
+    tags: dict | None = None,
+) -> dict:
+    return {
+        "type": "node",
+        "id": node_id,
+        "lat": lat,
+        "lon": lon,
+        "tags": tags or {"name": "Hotel Teste", "tourism": "hotel"},
+    }
+
+
+def _make_way(
+    way_id: int = 2,
+    center_lat: float = -27.5,
+    center_lon: float = -48.5,
+    tags: dict | None = None,
+) -> dict:
+    return {
+        "type": "way",
+        "id": way_id,
+        "center": {"lat": center_lat, "lon": center_lon},
+        "tags": tags or {"name": "Restaurante Teste", "amenity": "restaurant"},
+    }
+
+
+def _make_overpass_response(elements: list[dict]) -> dict:
+    return {"version": 0.6, "elements": elements}
+
+
+def _make_mock_http_response(status_code: int = 200, data: dict | None = None) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = data or _make_overpass_response([])
+    mock_resp.text = json.dumps(data or {})
+    return mock_resp
+
+
+def _make_record(**kwargs) -> RawEstablishment:
+    defaults = dict(
+        source="overpass",
+        source_id="node/1",
+        name="Hotel Teste",
+        latitude=-27.5,
+        longitude=-48.5,
+        raw_type="tourism=hotel",
+    )
+    defaults.update(kwargs)
+    return RawEstablishment(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _build_overpass_query
+# ---------------------------------------------------------------------------
+
+class TestBuildOverpassQuery:
+    def test_contains_key_value_pair(self) -> None:
+        q = _build_overpass_query("tourism", "hotel", FLORIANOPOLIS_BBOX)
+        assert "[tourism=hotel]" in q
+
+    def test_contains_bounding_box(self) -> None:
+        bbox = (-27.85, -48.65, -27.38, -48.33)
+        q = _build_overpass_query("amenity", "restaurant", bbox)
+        assert "-27.85,-48.65,-27.38,-48.33" in q
+
+    def test_requests_json_output(self) -> None:
+        q = _build_overpass_query("amenity", "cafe", FLORIANOPOLIS_BBOX)
+        assert "[out:json]" in q
+
+    def test_queries_both_nodes_and_ways(self) -> None:
+        q = _build_overpass_query("amenity", "bar", FLORIANOPOLIS_BBOX)
+        assert "node[amenity=bar]" in q
+        assert "way[amenity=bar]" in q
+
+    def test_requests_center_and_tags(self) -> None:
+        q = _build_overpass_query("tourism", "hostel", FLORIANOPOLIS_BBOX)
+        assert "out center tags;" in q
+
+
+# ---------------------------------------------------------------------------
+# _fetch_overpass
+# ---------------------------------------------------------------------------
+
+class TestFetchOverpass:
+    def test_returns_parsed_json_on_success(self) -> None:
+        expected = _make_overpass_response([_make_node()])
+        mock_resp = _make_mock_http_response(200, expected)
+
+        with patch("httpx.post", return_value=mock_resp):
+            result = _fetch_overpass("query", "https://overpass-api.de/api/interpreter")
+
+        assert result == expected
+
+    def test_posts_to_correct_url(self) -> None:
+        url = "https://overpass-api.de/api/interpreter"
+        mock_resp = _make_mock_http_response(200)
+
+        with patch("httpx.post", return_value=mock_resp) as mock_post:
+            _fetch_overpass("query text", url)
+
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == url
+        assert call_kwargs[1]["data"] == {"data": "query text"}
+
+    def test_raises_connection_error_on_429(self) -> None:
+        mock_resp = _make_mock_http_response(429)
+        with (
+            patch("httpx.post", return_value=mock_resp),
+            patch("time.sleep"),
+            pytest.raises(ConnectionError, match="rate limit"),
+        ):
+            _fetch_overpass("query", "https://overpass-api.de/api/interpreter")
+
+    def test_raises_connection_error_on_500(self) -> None:
+        mock_resp = _make_mock_http_response(500)
+        with (
+            patch("httpx.post", return_value=mock_resp),
+            patch("time.sleep"),
+            pytest.raises(ConnectionError, match="status 500"),
+        ):
+            _fetch_overpass("query", "https://overpass-api.de/api/interpreter")
+
+    def test_wraps_httpx_timeout_as_connection_error(self) -> None:
+        import httpx as _httpx
+        with (
+            patch("httpx.post", side_effect=_httpx.TimeoutException("timed out")),
+            patch("time.sleep"),
+            pytest.raises(ConnectionError, match="Overpass API request failed"),
+        ):
+            _fetch_overpass("query", "https://overpass-api.de/api/interpreter")
+
+    def test_retries_on_connection_error(self) -> None:
+        success_resp = _make_mock_http_response(200)
+        with (
+            patch(
+                "httpx.post",
+                side_effect=[
+                    ConnectionError("transient"),
+                    ConnectionError("transient"),
+                    success_resp,
+                ],
+            ),
+            patch("time.sleep"),
+        ):
+            # Third attempt should succeed — no exception raised
+            result = _fetch_overpass("query", "https://overpass-api.de/api/interpreter")
+
+        assert "elements" in result
+
+
+# ---------------------------------------------------------------------------
+# _parse_element
+# ---------------------------------------------------------------------------
+
+class TestParseElement:
+    def test_parses_node_with_full_tags(self) -> None:
+        node = _make_node(
+            node_id=42,
+            lat=-27.6,
+            lon=-48.4,
+            tags={
+                "name": "Pousada do Mar",
+                "tourism": "guest_house",
+                "phone": "+55 48 3333-1111",
+                "website": "https://pousadadomar.com.br",
+                "opening_hours": "Mo-Su 08:00-22:00",
+                "cuisine": "seafood",
+                "addr:street": "Rua das Flores",
+                "addr:housenumber": "123",
+                "addr:city": "Florianópolis",
+            },
+        )
+        record = _parse_element(node, "tourism", "guest_house")
+
+        assert record is not None
+        assert record.source == "overpass"
+        assert record.source_id == "node/42"
+        assert record.name == "Pousada do Mar"
+        assert record.latitude == pytest.approx(-27.6)
+        assert record.longitude == pytest.approx(-48.4)
+        assert record.raw_type == "tourism=guest_house"
+        assert record.phone == "+55 48 3333-1111"
+        assert record.website == "https://pousadadomar.com.br"
+        assert record.opening_hours == "Mo-Su 08:00-22:00"
+        assert record.cuisine == "seafood"
+        assert "Rua das Flores" in (record.address or "")
+
+    def test_parses_way_using_center_coords(self) -> None:
+        way = _make_way(way_id=99, center_lat=-27.7, center_lon=-48.55)
+        record = _parse_element(way, "amenity", "restaurant")
+
+        assert record is not None
+        assert record.source_id == "way/99"
+        assert record.latitude == pytest.approx(-27.7)
+        assert record.longitude == pytest.approx(-48.55)
+        assert record.raw_type == "amenity=restaurant"
+
+    def test_returns_none_when_node_missing_lat(self) -> None:
+        node = {"type": "node", "id": 1, "lon": -48.5, "tags": {}}
+        assert _parse_element(node, "tourism", "hotel") is None
+
+    def test_returns_none_when_way_missing_center(self) -> None:
+        way = {"type": "way", "id": 2, "tags": {}}
+        assert _parse_element(way, "amenity", "bar") is None
+
+    def test_uses_contact_phone_fallback(self) -> None:
+        node = _make_node(tags={"name": "Bar X", "contact:phone": "+55 48 9999-0000", "amenity": "bar"})
+        record = _parse_element(node, "amenity", "bar")
+        assert record is not None
+        assert record.phone == "+55 48 9999-0000"
+
+    def test_uses_contact_website_fallback(self) -> None:
+        node = _make_node(tags={"name": "Cafe Y", "contact:website": "https://cafe.com", "amenity": "cafe"})
+        record = _parse_element(node, "amenity", "cafe")
+        assert record is not None
+        assert record.website == "https://cafe.com"
+
+    def test_non_standard_tags_go_to_extra_data(self) -> None:
+        node = _make_node(
+            tags={"name": "Hotel Z", "tourism": "hotel", "stars": "4", "wheelchair": "yes"}
+        )
+        record = _parse_element(node, "tourism", "hotel")
+        assert record is not None
+        assert record.extra_data is not None
+        assert record.extra_data.get("stars") == "4"
+        assert record.extra_data.get("wheelchair") == "yes"
+
+    def test_extra_data_is_none_when_no_extra_tags(self) -> None:
+        node = _make_node(tags={"name": "Hostel Mínimo", "tourism": "hostel"})
+        record = _parse_element(node, "tourism", "hostel")
+        assert record is not None
+        assert record.extra_data is None
+
+    def test_returns_none_for_validation_failure(self) -> None:
+        # latitude out of valid range should trigger Pydantic validation error
+        node = {"type": "node", "id": 1, "lat": 999.0, "lon": -48.5, "tags": {}}
+        assert _parse_element(node, "tourism", "hotel") is None
+
+
+# ---------------------------------------------------------------------------
+# _insert_batch
+# ---------------------------------------------------------------------------
+
+class TestInsertBatch:
+    def test_returns_zero_for_empty_list(self) -> None:
+        assert _insert_batch([], "batch-1") == 0
+
+    def test_inserts_to_raw_crawled_data_table(self) -> None:
+        records = [_make_record()]
+        mock_client = MagicMock()
+        mock_client.table.return_value.upsert.return_value.execute.return_value.data = [
+            {"id": "abc"}
+        ]
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            count = _insert_batch(records, "batch-1")
+
+        mock_client.table.assert_called_with("raw_crawled_data")
+        assert count == 1
+
+    def test_maps_fields_to_db_columns(self) -> None:
+        records = [_make_record(source_id="node/42", name="Hotel Mar")]
+        mock_client = MagicMock()
+        mock_client.table.return_value.upsert.return_value.execute.return_value.data = []
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            _insert_batch(records, "batch-xyz")
+
+        upsert_args = mock_client.table.return_value.upsert.call_args
+        row = upsert_args[0][0][0]
+
+        assert row["source"] == "overpass"
+        assert row["source_id"] == "node/42"
+        assert row["batch_id"] == "batch-xyz"
+        assert isinstance(row["payload"], dict)
+        assert row["payload"]["name"] == "Hotel Mar"
+
+    def test_returns_zero_when_all_duplicates(self) -> None:
+        records = [_make_record()]
+        mock_client = MagicMock()
+        mock_client.table.return_value.upsert.return_value.execute.return_value.data = []
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            count = _insert_batch(records, "batch-1")
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# _log_pipeline
+# ---------------------------------------------------------------------------
+
+class TestLogPipeline:
+    def test_writes_running_status(self) -> None:
+        mock_client = MagicMock()
+        mock_client.table.return_value.insert.return_value.execute.return_value.data = []
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            _log_pipeline(batch_id="b1", status="running")
+
+        mock_client.table.assert_called_with("data_pipeline_logs")
+        row = mock_client.table.return_value.insert.call_args[0][0]
+        assert row["status"] == "running"
+        assert row["pipeline_name"] == "overpass_osm_extractor"
+        assert row["batch_id"] == "b1"
+
+    def test_includes_duration_ms_when_both_timestamps_provided(self) -> None:
+        mock_client = MagicMock()
+        mock_client.table.return_value.insert.return_value.execute.return_value.data = []
+
+        started = datetime(2024, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        finished = datetime(2024, 6, 1, 10, 0, 3, tzinfo=timezone.utc)  # 3 seconds
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            _log_pipeline(
+                batch_id="b1",
+                status="success",
+                started_at=started,
+                finished_at=finished,
+            )
+
+        row = mock_client.table.return_value.insert.call_args[0][0]
+        assert row["duration_ms"] == 3000
+
+    def test_does_not_raise_on_supabase_error(self) -> None:
+        mock_client = MagicMock()
+        mock_client.table.side_effect = Exception("DB unavailable")
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            # Must not raise
+            _log_pipeline(batch_id="b1", status="running")
+
+    def test_includes_error_message_on_failure_status(self) -> None:
+        mock_client = MagicMock()
+        mock_client.table.return_value.insert.return_value.execute.return_value.data = []
+
+        with patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client):
+            _log_pipeline(batch_id="b1", status="error", error_message="API timed out")
+
+        row = mock_client.table.return_value.insert.call_args[0][0]
+        assert row["error_message"] == "API timed out"
+
+
+# ---------------------------------------------------------------------------
+# run_extraction (integration-style, all I/O mocked)
+# ---------------------------------------------------------------------------
+
+class TestRunExtraction:
+    def _make_mock_client(self, inserted_count: int = 1) -> MagicMock:
+        mock = MagicMock()
+        mock.table.return_value.upsert.return_value.execute.return_value.data = (
+            [{"id": str(i)} for i in range(inserted_count)]
+        )
+        mock.table.return_value.insert.return_value.execute.return_value.data = []
+        return mock
+
+    def _make_http_resp_with_node(self, node_id: int = 1) -> MagicMock:
+        data = _make_overpass_response([_make_node(node_id=node_id)])
+        return _make_mock_http_response(200, data)
+
+    def test_returns_total_inserted_count(self) -> None:
+        mock_client = self._make_mock_client(inserted_count=1)
+        http_resp = self._make_http_resp_with_node()
+
+        with (
+            patch("httpx.post", return_value=http_resp),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            total = run_extraction()
+
+        # 7 queries × 1 node each = 7 inserts
+        assert total == 7
+
+    def test_all_seven_categories_are_queried(self) -> None:
+        mock_client = self._make_mock_client(inserted_count=0)
+        http_resp = _make_mock_http_response(200)
+        posted_queries: list[str] = []
+
+        def capture_post(url: str, **kwargs: object) -> MagicMock:
+            posted_queries.append(kwargs.get("data", {}).get("data", ""))  # type: ignore[union-attr]
+            return http_resp
+
+        with (
+            patch("httpx.post", side_effect=capture_post),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            run_extraction()
+
+        assert len(posted_queries) == len(OVERPASS_QUERIES)
+        all_queries_joined = " ".join(posted_queries)
+        for qcfg in OVERPASS_QUERIES:
+            assert f"{qcfg['key']}={qcfg['value']}" in all_queries_joined
+
+    def test_respects_cooldown_between_queries(self) -> None:
+        mock_client = self._make_mock_client(inserted_count=0)
+        http_resp = _make_mock_http_response(200)
+
+        with (
+            patch("httpx.post", return_value=http_resp),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep") as mock_sleep,
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            run_extraction()
+
+        # 7 queries → 6 sleeps (no sleep before first query)
+        assert mock_sleep.call_count == len(OVERPASS_QUERIES) - 1
+
+    def test_logs_running_then_success(self) -> None:
+        mock_client = self._make_mock_client(inserted_count=0)
+        http_resp = _make_mock_http_response(200)
+
+        with (
+            patch("httpx.post", return_value=http_resp),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            run_extraction()
+
+        log_rows = [
+            call[0][0]
+            for call in mock_client.table.return_value.insert.call_args_list
+        ]
+        statuses = [r["status"] for r in log_rows]
+        assert "running" in statuses
+        assert "success" in statuses
+
+    def test_logs_error_status_on_api_failure(self) -> None:
+        import httpx as _httpx
+
+        mock_client = MagicMock()
+        mock_client.table.return_value.insert.return_value.execute.return_value.data = []
+
+        with (
+            patch("httpx.post", side_effect=_httpx.NetworkError("Overpass down")),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+            pytest.raises(ConnectionError),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            run_extraction()
+
+        log_rows = [call[0][0] for call in mock_client.table.return_value.insert.call_args_list]
+        statuses = [r["status"] for r in log_rows]
+        assert "error" in statuses
+
+    def test_groups_all_records_under_single_batch_id(self) -> None:
+        mock_client = self._make_mock_client(inserted_count=0)
+        http_resp = self._make_http_resp_with_node()
+
+        with (
+            patch("httpx.post", return_value=http_resp),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            run_extraction()
+
+        # Collect batch_ids from every upsert call
+        batch_ids: set[str] = set()
+        for call in mock_client.table.return_value.upsert.call_args_list:
+            rows = call[0][0]
+            for row in rows:
+                batch_ids.add(row["batch_id"])
+
+        assert len(batch_ids) == 1, "All records must share a single batch_id"
+
+    def test_skips_elements_without_coordinates(self) -> None:
+        no_coord_element = {"type": "node", "id": 5, "tags": {"name": "Ghost"}}
+        data = _make_overpass_response([no_coord_element])
+        http_resp = _make_mock_http_response(200, data)
+        mock_client = self._make_mock_client(inserted_count=0)
+
+        with (
+            patch("httpx.post", return_value=http_resp),
+            patch("src.extractors.overpass_osm.get_supabase_client", return_value=mock_client),
+            patch("src.extractors.overpass_osm.get_settings") as mock_settings,
+            patch("time.sleep"),
+        ):
+            mock_settings.return_value.OVERPASS_API_URL = "https://overpass-api.de/api/interpreter"
+            total = run_extraction()
+
+        assert total == 0


### PR DESCRIPTION
Closes #2

## Summary

- Implements `src/extractors/overpass_osm.py` — queries the Overpass API for 7 hospitality categories (`tourism=hotel|hostel|guest_house`, `amenity=restaurant|cafe|bar|pub`) within the Florianópolis bounding box `(-27.85, -48.65, -27.38, -48.33)`
- Validates each OSM element via `RawEstablishment` (Pydantic) and upserts into `raw_crawled_data` with `source='overpass'` under a shared `batch_id`
- Handles 429 rate-limit responses by raising `ConnectionError` so the existing `@with_retry` decorator backs off automatically
- Enforces max-2-concurrent via `threading.Semaphore(2)` and a 10 s cooldown between sequential queries
- Logs pipeline events (`running` / `success` / `error`) to `data_pipeline_logs`

## Test plan

- [x] 35 unit tests in `tests/test_extractors/test_overpass_osm.py` — all offline, no real credentials needed
- [x] Coverage: `_build_overpass_query`, `_fetch_overpass` (success, 429, 500, timeout, retry), `_parse_element` (node, way, missing coords, fallback fields, extra_data, validation failure), `_insert_batch`, `_log_pipeline`, `run_extraction` (count, all 7 queries, cooldown, logging, single batch_id, skipped elements)
- [x] Existing test suite unaffected — 57/57 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)