### PR TITLE
feat: LLM classification pipeline — raw_crawled_data → dim_estabelecimentos

### DIFF
--- a/sql/008_classifier_functions.sql
+++ b/sql/008_classifier_functions.sql
@@ -1,0 +1,58 @@
+-- ============================================================
+-- Migration 008: LLM Classifier Support Functions
+-- ============================================================
+-- PostgreSQL helper functions used by the LLM classification
+-- pipeline (src/transformers/llm_classifier.py).
+--
+-- Requires: pg_trgm (migration 001), PostGIS (migration 001),
+--           dim_estabelecimentos (migration 003).
+-- ============================================================
+
+-- ----------------------------------------------------------------
+-- check_establishment_duplicate
+-- ----------------------------------------------------------------
+-- Returns the UUID of an existing active establishment that matches
+-- the given name (pg_trgm similarity > threshold) AND is within
+-- the given distance in meters (PostGIS ST_DWithin).
+--
+-- Called by the classifier before every INSERT to avoid creating
+-- duplicate dimension records from different extraction sources.
+--
+-- Args:
+--   p_nome               Standardized establishment name to check
+--   p_lat                Latitude in decimal degrees (WGS84)
+--   p_lon                Longitude in decimal degrees (WGS84)
+--   p_similarity_threshold  Minimum trigram similarity (default 0.8)
+--   p_distance_meters    Maximum spatial distance in metres (default 50)
+--
+-- Returns:
+--   UUID of the most similar active duplicate, or NULL if none found.
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION check_establishment_duplicate(
+    p_nome                  text,
+    p_lat                   double precision,
+    p_lon                   double precision,
+    p_similarity_threshold  float DEFAULT 0.8,
+    p_distance_meters       float DEFAULT 50.0
+)
+RETURNS uuid
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT id
+    FROM public.dim_estabelecimentos
+    WHERE ativo = true
+      AND extensions.similarity(nome, p_nome) > p_similarity_threshold
+      AND ST_DWithin(
+            location,
+            ST_SetSRID(ST_MakePoint(p_lon, p_lat), 4326)::extensions.geography,
+            p_distance_meters
+          )
+    ORDER BY extensions.similarity(nome, p_nome) DESC
+    LIMIT 1;
+$$;
+
+COMMENT ON FUNCTION check_establishment_duplicate IS
+    'Returns the UUID of an existing dim_estabelecimentos record that fuzzy-matches the given
+     name (pg_trgm similarity > threshold) and is within p_distance_meters of the coordinates.
+     Returns NULL when no duplicate is found. Used by the LLM classifier to prevent duplicate rows.';

--- a/src/transformers/llm_classifier.py
+++ b/src/transformers/llm_classifier.py
@@ -1,0 +1,505 @@
+"""
+LLM Classifier Transformer
+===========================
+Reads unprocessed records from ``raw_crawled_data``, classifies each
+establishment via Ollama (structured JSON output), and writes clean
+records to ``dim_estabelecimentos``.
+
+Data flow::
+
+    raw_crawled_data (processed=false)
+        → RawEstablishment (Pydantic validation)
+        → Ollama structured output (ClassifiedEstablishment schema)
+        → Fuzzy dedup check (pg_trgm via check_establishment_duplicate RPC)
+        → dim_estabelecimentos INSERT
+        → raw_crawled_data.processed = true
+
+Deduplication strategy:
+    Before every INSERT the pipeline calls the ``check_establishment_duplicate``
+    PostgreSQL function (migration 008).  If a record with trigram similarity
+    > 0.8 AND PostGIS distance < 50 m already exists, the raw record is marked
+    as processed and skipped — no duplicate dimension row is created.
+
+Usage::
+
+    python -m src.transformers.llm_classifier
+    python -m src.transformers.llm_classifier --batch-size 50
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import ollama
+
+from src.config.settings import get_settings
+from src.config.supabase_client import get_supabase_client
+from src.models.estabelecimento import (
+    ClassifiedEstablishment,
+    RawEstablishment,
+)
+from src.utils.logger import get_logger
+from src.utils.retry import with_retry
+
+logger = get_logger(__name__)
+
+_BATCH_SIZE = 20          # default records per classification run
+_LLM_TEMPERATURE = 0.1   # low temperature for deterministic output
+
+SYSTEM_PROMPT = (
+    "You are a hospitality industry data analyst specializing in Florianópolis, Brazil. "
+    "Classify establishments from raw OSM or web-scraped data into structured records.\n\n"
+    "Guidelines:\n"
+    "- Standardize names: fix capitalization and accents, remove noise "
+    '(e.g., "HOTEL BEIRA MAR LTDA" → "Hotel Beira Mar").\n'
+    "- Classify type using only the allowed enum values.\n"
+    "- Suggest CNAE codes: 5510-8/01 (hotels), 5590-6/01 (hostels/pousadas), "
+    "5611-2/01 (restaurants), 5611-2/03 (lanchonetes/fast-food), "
+    "5611-2/05 (bares/botequins), 5620-1/04 (cafés).\n"
+    "- Estimate the Florianópolis neighborhood from the coordinates and address.\n"
+    "- Generate concise, useful tags such as pet_friendly, wifi, ocean_view, "
+    "pool, parking, outdoor_seating, delivery.\n"
+    "- Set confidence ≥ 0.9 only when name, type, and location are all clearly "
+    "identifiable. Use confidence < 0.6 when the establishment type is ambiguous."
+)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _build_prompt(raw: RawEstablishment) -> str:
+    """
+    Build a user-turn prompt from a validated RawEstablishment.
+
+    Includes all non-null fields from the raw record so the LLM has the
+    maximum available context for classification.
+
+    Args:
+        raw: Validated RawEstablishment instance.
+
+    Returns:
+        Formatted prompt string ready to send to the LLM.
+    """
+    parts = [
+        f"Name: {raw.name or '(unknown)'}",
+        f"OSM type: {raw.raw_type or '(unknown)'}",
+        f"Coordinates: lat={raw.latitude}, lon={raw.longitude}",
+    ]
+    if raw.address:
+        parts.append(f"Address: {raw.address}")
+    if raw.cuisine:
+        parts.append(f"Cuisine: {raw.cuisine}")
+    if raw.phone:
+        parts.append(f"Phone: {raw.phone}")
+    if raw.website:
+        parts.append(f"Website: {raw.website}")
+    if raw.opening_hours:
+        parts.append(f"Opening hours: {raw.opening_hours}")
+    if raw.extra_data:
+        useful_keys = {
+            "stars", "rooms", "wheelchair", "internet_access",
+            "outdoor_seating", "takeaway", "delivery", "smoking",
+            "air_conditioning", "payment:cash", "payment:cards",
+        }
+        useful = {k: v for k, v in raw.extra_data.items() if k in useful_keys}
+        if useful:
+            parts.append(f"Extra attributes: {useful}")
+
+    return (
+        "Classify this hospitality establishment from Florianópolis, SC, Brazil:\n\n"
+        + "\n".join(parts)
+        + "\n\nReturn a JSON object matching the required schema."
+    )
+
+
+@with_retry(
+    max_attempts=3,
+    base_delay=2.0,
+    retryable_exceptions=(ConnectionError, TimeoutError, OSError),
+)
+def _classify_with_llm(
+    raw: RawEstablishment,
+    ollama_url: str,
+    ollama_model: str,
+) -> ClassifiedEstablishment:
+    """
+    Classify a raw establishment using Ollama with structured JSON output.
+
+    Passes ``ClassifiedEstablishment.model_json_schema()`` as the ``format``
+    parameter, which forces the Ollama model to emit a JSON object that
+    conforms to the schema on every call.
+
+    Args:
+        raw: Validated RawEstablishment to classify.
+        ollama_url: Ollama server base URL (e.g. ``http://localhost:11434``).
+        ollama_model: Model identifier (e.g. ``llama3.1:8b``).
+
+    Returns:
+        Validated ClassifiedEstablishment instance.
+
+    Raises:
+        ConnectionError: On Ollama network failures (triggers with_retry backoff).
+        ValueError: On malformed LLM JSON (does not trigger retry).
+    """
+    client = ollama.Client(host=ollama_url)
+    prompt = _build_prompt(raw)
+
+    try:
+        response = client.chat(
+            model=ollama_model,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            format=ClassifiedEstablishment.model_json_schema(),
+            options={"temperature": _LLM_TEMPERATURE},
+        )
+    except Exception as exc:
+        msg = str(exc).lower()
+        if any(kw in msg for kw in ("connection", "refused", "timeout", "network")):
+            raise ConnectionError(f"Ollama connection failed: {exc}") from exc
+        raise ConnectionError(f"Ollama API error: {exc}") from exc
+
+    return ClassifiedEstablishment.model_validate_json(response.message.content)
+
+
+def _is_duplicate(
+    client: Any,
+    name: str,
+    lat: float,
+    lon: float,
+) -> str | None:
+    """
+    Check for a fuzzy-duplicate establishment in ``dim_estabelecimentos``.
+
+    Delegates to the ``check_establishment_duplicate`` PostgreSQL function
+    (migration 008) which combines pg_trgm similarity > 0.8 with a 50 m
+    PostGIS proximity filter.
+
+    If the RPC call fails (e.g., the function is not yet deployed), the error
+    is logged as a warning and ``None`` is returned — the pipeline continues
+    without dedup protection rather than crashing.
+
+    Args:
+        client: Supabase client instance.
+        name: Standardized establishment name to check.
+        lat: Latitude in decimal degrees.
+        lon: Longitude in decimal degrees.
+
+    Returns:
+        UUID string of an existing duplicate record, or ``None``.
+    """
+    try:
+        result = client.rpc(
+            "check_establishment_duplicate",
+            {"p_nome": name, "p_lat": lat, "p_lon": lon},
+        ).execute()
+        return result.data if result.data else None
+    except Exception as exc:
+        logger.warning("dedup_check_failed", name=name, error=str(exc))
+        return None
+
+
+def _build_dim_row(
+    raw: RawEstablishment,
+    classified: ClassifiedEstablishment,
+) -> dict[str, Any]:
+    """
+    Merge raw extraction data and LLM classification into a ``dim_estabelecimentos`` row.
+
+    The PostGIS ``location`` column accepts WKT strings in the format
+    ``SRID=4326;POINT(lon lat)``; Postgres casts this to
+    ``geography(Point, 4326)`` on insert.
+
+    Cuisine is converted from the OSM semicolon-separated string
+    (e.g. ``"italian;seafood"``) to a PostgreSQL text array.
+
+    Args:
+        raw: Validated RawEstablishment from the extraction phase.
+        classified: Validated ClassifiedEstablishment from the LLM phase.
+
+    Returns:
+        Dictionary ready for ``client.table("dim_estabelecimentos").insert()``.
+    """
+    source_refs: dict[str, str] = {}
+    if raw.source_id:
+        source_refs["osm_id" if raw.source == "overpass" else raw.source] = raw.source_id
+
+    cuisine_list: list[str] | None = None
+    if raw.cuisine:
+        cuisine_list = [c.strip() for c in raw.cuisine.split(";") if c.strip()]
+
+    return {
+        "nome": classified.standardized_name,
+        "nome_original": raw.name,
+        "tipo": classified.type.value,
+        "subtipo": classified.subtype,
+        "cnae_codigo": classified.suggested_cnae,
+        "endereco": raw.address,
+        "bairro": classified.estimated_neighborhood,
+        "location": f"SRID=4326;POINT({raw.longitude} {raw.latitude})",
+        "telefone": raw.phone,
+        "website": raw.website,
+        "horario_funcionamento": raw.opening_hours,
+        "rating_google": raw.rating,
+        "total_reviews": raw.review_count,
+        "cuisine": cuisine_list,
+        "tags_llm": {
+            "tags": classified.tags,
+            "confidence": classified.confidence,
+            "subtype": classified.subtype,
+        },
+        "source_refs": source_refs,
+        "ativo": True,
+    }
+
+
+def _insert_dim_record(client: Any, row: dict[str, Any]) -> int:
+    """
+    Insert one record into ``dim_estabelecimentos``.
+
+    Args:
+        client: Supabase client instance.
+        row: Dict produced by ``_build_dim_row``.
+
+    Returns:
+        1 if the row was inserted, 0 otherwise.
+    """
+    result = client.table("dim_estabelecimentos").insert(row).execute()
+    return len(result.data) if result.data else 0
+
+
+def _mark_processed(client: Any, record_ids: list[str]) -> None:
+    """
+    Set ``processed = true`` on raw_crawled_data records.
+
+    Called after classification (whether the record was inserted, skipped as
+    a duplicate, or skipped due to missing coordinates). Idempotent.
+
+    Args:
+        client: Supabase client instance.
+        record_ids: List of ``raw_crawled_data`` UUID strings to mark.
+    """
+    if not record_ids:
+        return
+    (
+        client.table("raw_crawled_data")
+        .update({"processed": True})
+        .in_("id", record_ids)
+        .execute()
+    )
+
+
+def _log_pipeline(
+    batch_id: str,
+    status: str,
+    records_processed: int = 0,
+    error_message: str | None = None,
+    started_at: datetime | None = None,
+    finished_at: datetime | None = None,
+) -> None:
+    """Write a pipeline execution record to data_pipeline_logs. Failures are swallowed."""
+    try:
+        client = get_supabase_client()
+        row: dict[str, Any] = {
+            "pipeline_name": "llm_classifier",
+            "batch_id": batch_id,
+            "status": status,
+            "records_processed": records_processed,
+            "github_run_id": os.getenv("GITHUB_RUN_ID"),
+            "github_workflow": os.getenv("GITHUB_WORKFLOW"),
+        }
+        if error_message is not None:
+            row["error_message"] = error_message
+        if started_at is not None:
+            row["started_at"] = started_at.isoformat()
+        if finished_at is not None:
+            row["finished_at"] = finished_at.isoformat()
+            if started_at is not None:
+                row["duration_ms"] = int((finished_at - started_at).total_seconds() * 1000)
+        client.table("data_pipeline_logs").insert(row).execute()
+    except Exception as exc:
+        logger.error("pipeline_log_write_failed", error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def run_classification(batch_size: int = _BATCH_SIZE) -> int:
+    """
+    Run one batch of the LLM classification pipeline.
+
+    Processing loop for each raw record:
+
+    1. Validate the JSONB payload into a ``RawEstablishment``.
+    2. Skip records with no coordinates (mark as processed).
+    3. Call ``check_establishment_duplicate`` RPC — skip if found.
+    4. Classify via Ollama (``@with_retry`` for transient errors).
+    5. Insert classified record into ``dim_estabelecimentos``.
+    6. Collect the record ID for bulk ``processed = true`` update.
+
+    LLM errors are logged and the record is **not** marked as processed,
+    so it will be retried in the next batch run.
+
+    Args:
+        batch_size: Maximum number of raw records to process per run.
+
+    Returns:
+        Number of records successfully classified and inserted.
+    """
+    settings = get_settings()
+    client = get_supabase_client()
+    batch_id = str(uuid.uuid4())
+    started_at = datetime.now(tz=timezone.utc)
+
+    _log_pipeline(batch_id=batch_id, status="running", started_at=started_at)
+    logger.info(
+        "classification_started",
+        pipeline="llm_classifier",
+        batch_size=batch_size,
+        model=settings.OLLAMA_MODEL,
+    )
+
+    # --- Fetch unprocessed records ---
+    raw_rows: list[dict[str, Any]] = (
+        client.table("raw_crawled_data")
+        .select("*")
+        .eq("processed", False)
+        .limit(batch_size)
+        .execute()
+    ).data or []
+
+    if not raw_rows:
+        finished_at = datetime.now(tz=timezone.utc)
+        logger.info("no_unprocessed_records", pipeline="llm_classifier")
+        _log_pipeline(
+            batch_id=batch_id,
+            status="skipped",
+            records_processed=0,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        return 0
+
+    logger.info("raw_records_fetched", count=len(raw_rows))
+
+    classified_count = 0
+    processed_ids: list[str] = []
+
+    try:
+        for row in raw_rows:
+            record_id: str = row["id"]
+
+            # Step 1 — Validate payload
+            try:
+                raw = RawEstablishment.model_validate(row["payload"])
+            except Exception as exc:
+                logger.warning("raw_validation_failed", record_id=record_id, error=str(exc))
+                processed_ids.append(record_id)
+                continue
+
+            if raw.latitude is None or raw.longitude is None:
+                logger.warning("skipping_no_coordinates", record_id=record_id)
+                processed_ids.append(record_id)
+                continue
+
+            # Step 2 — Fuzzy dedup
+            duplicate_id = _is_duplicate(
+                client, raw.name or "", raw.latitude, raw.longitude
+            )
+            if duplicate_id:
+                logger.info(
+                    "duplicate_skipped",
+                    record_id=record_id,
+                    duplicate_dim_id=duplicate_id,
+                )
+                processed_ids.append(record_id)
+                continue
+
+            # Step 3 — LLM classification
+            try:
+                classified = _classify_with_llm(
+                    raw, settings.OLLAMA_URL, settings.OLLAMA_MODEL
+                )
+            except Exception as exc:
+                logger.error(
+                    "classification_failed",
+                    record_id=record_id,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+                # Do NOT mark as processed — will retry in next batch
+                continue
+
+            logger.info(
+                "record_classified",
+                record_id=record_id,
+                name=classified.standardized_name,
+                type=classified.type.value,
+                confidence=classified.confidence,
+            )
+
+            # Step 4 — Insert into dim_estabelecimentos
+            try:
+                dim_row = _build_dim_row(raw, classified)
+                _insert_dim_record(client, dim_row)
+                classified_count += 1
+            except Exception as exc:
+                logger.error("dim_insert_failed", record_id=record_id, error=str(exc))
+                continue
+
+            processed_ids.append(record_id)
+
+        # Step 5 — Bulk mark as processed
+        _mark_processed(client, processed_ids)
+        logger.info("records_marked_processed", count=len(processed_ids))
+
+    except Exception as exc:
+        finished_at = datetime.now(tz=timezone.utc)
+        logger.error("pipeline_failed", error=str(exc), error_type=type(exc).__name__)
+        _log_pipeline(
+            batch_id=batch_id,
+            status="error",
+            records_processed=classified_count,
+            error_message=str(exc),
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+        raise
+
+    finished_at = datetime.now(tz=timezone.utc)
+    _log_pipeline(
+        batch_id=batch_id,
+        status="success",
+        records_processed=classified_count,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    logger.info(
+        "pipeline_complete",
+        pipeline="llm_classifier",
+        total_classified=classified_count,
+        total_processed=len(processed_ids),
+        duration_ms=int((finished_at - started_at).total_seconds() * 1000),
+    )
+    return classified_count
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run LLM classification pipeline")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=_BATCH_SIZE,
+        help=f"Records per run (default: {_BATCH_SIZE})",
+    )
+    args = parser.parse_args()
+    total = run_classification(batch_size=args.batch_size)
+    print(f"Classified {total} establishments.")

--- a/tests/test_transformers/test_llm_classifier.py
+++ b/tests/test_transformers/test_llm_classifier.py
@@ -1,0 +1,630 @@
+"""
+Unit tests for the LLM classifier transformer.
+
+All external dependencies (Ollama, Supabase, settings) are mocked so
+these tests run fully offline without any real credentials or models.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.models.estabelecimento import ClassifiedEstablishment, EstablishmentType, RawEstablishment
+from src.transformers.llm_classifier import (
+    _BATCH_SIZE,
+    _build_dim_row,
+    _build_prompt,
+    _classify_with_llm,
+    _insert_dim_record,
+    _is_duplicate,
+    _log_pipeline,
+    _mark_processed,
+    run_classification,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_raw(**kwargs) -> RawEstablishment:
+    defaults = dict(
+        source="overpass",
+        source_id="node/1",
+        name="Hotel Beira Mar",
+        latitude=-27.59,
+        longitude=-48.54,
+        raw_type="tourism=hotel",
+    )
+    defaults.update(kwargs)
+    return RawEstablishment(**defaults)
+
+
+def _make_classified(**kwargs) -> ClassifiedEstablishment:
+    defaults = dict(
+        standardized_name="Hotel Beira Mar",
+        type=EstablishmentType.HOTEL,
+        subtype="boutique_hotel",
+        suggested_cnae="5510-8/01",
+        estimated_neighborhood="Centro",
+        tags=["wifi", "ocean_view"],
+        confidence=0.95,
+    )
+    defaults.update(kwargs)
+    return ClassifiedEstablishment(**defaults)
+
+
+def _make_raw_row(
+    record_id: str = "uuid-1",
+    payload: dict | None = None,
+) -> dict:
+    raw = _make_raw()
+    return {
+        "id": record_id,
+        "source": "overpass",
+        "source_id": "node/1",
+        "payload": payload if payload is not None else raw.model_dump(mode="json"),
+        "processed": False,
+        "batch_id": "batch-abc",
+    }
+
+
+def _classified_json(**kwargs) -> str:
+    return _make_classified(**kwargs).model_dump_json()
+
+
+def _make_mock_supabase(
+    raw_rows: list[dict] | None = None,
+    insert_data: list[dict] | None = None,
+    rpc_data: str | None = None,
+) -> MagicMock:
+    client = MagicMock()
+
+    # raw_crawled_data SELECT
+    client.table.return_value.select.return_value.eq.return_value.limit.return_value.execute.return_value.data = (
+        raw_rows if raw_rows is not None else []
+    )
+
+    # dim_estabelecimentos INSERT
+    client.table.return_value.insert.return_value.execute.return_value.data = (
+        insert_data if insert_data is not None else [{"id": "dim-uuid-1"}]
+    )
+
+    # data_pipeline_logs INSERT
+    client.table.return_value.insert.return_value.execute.return_value.data = []
+
+    # RPC dedup check
+    client.rpc.return_value.execute.return_value.data = rpc_data
+
+    return client
+
+
+def _make_ollama_response(content: str) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.message.content = content
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildPrompt:
+    def test_includes_name_and_type(self) -> None:
+        raw = _make_raw(name="Restaurante do Porto", raw_type="amenity=restaurant")
+        prompt = _build_prompt(raw)
+        assert "Restaurante do Porto" in prompt
+        assert "amenity=restaurant" in prompt
+
+    def test_includes_coordinates(self) -> None:
+        raw = _make_raw(latitude=-27.59, longitude=-48.54)
+        prompt = _build_prompt(raw)
+        assert "-27.59" in prompt
+        assert "-48.54" in prompt
+
+    def test_includes_optional_fields_when_present(self) -> None:
+        raw = _make_raw(
+            address="Rua das Flores, 10",
+            cuisine="seafood",
+            phone="+55 48 3333-0000",
+            website="https://example.com",
+            opening_hours="Mo-Su 11:00-23:00",
+        )
+        prompt = _build_prompt(raw)
+        assert "Rua das Flores" in prompt
+        assert "seafood" in prompt
+        assert "+55 48 3333-0000" in prompt
+        assert "https://example.com" in prompt
+        assert "Mo-Su 11:00-23:00" in prompt
+
+    def test_omits_none_optional_fields(self) -> None:
+        raw = _make_raw(address=None, cuisine=None, phone=None)
+        prompt = _build_prompt(raw)
+        assert "Address:" not in prompt
+        assert "Cuisine:" not in prompt
+        assert "Phone:" not in prompt
+
+    def test_includes_useful_extra_data(self) -> None:
+        raw = _make_raw(extra_data={"stars": "4", "wheelchair": "yes", "irrelevant": "x"})
+        prompt = _build_prompt(raw)
+        assert "stars" in prompt
+        assert "wheelchair" in prompt
+
+    def test_unknown_name_shown_as_unknown(self) -> None:
+        raw = _make_raw(name=None)
+        prompt = _build_prompt(raw)
+        assert "(unknown)" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _classify_with_llm
+# ---------------------------------------------------------------------------
+
+class TestClassifyWithLlm:
+    def test_returns_classified_establishment_on_success(self) -> None:
+        raw = _make_raw()
+        content = _classified_json()
+        mock_resp = _make_ollama_response(content)
+
+        with patch("src.transformers.llm_classifier.ollama.Client") as MockClient:
+            MockClient.return_value.chat.return_value = mock_resp
+            result = _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+        assert result.standardized_name == "Hotel Beira Mar"
+        assert result.type == EstablishmentType.HOTEL
+        assert result.confidence == pytest.approx(0.95)
+
+    def test_passes_schema_as_format(self) -> None:
+        raw = _make_raw()
+        mock_resp = _make_ollama_response(_classified_json())
+
+        with patch("src.transformers.llm_classifier.ollama.Client") as MockClient:
+            MockClient.return_value.chat.return_value = mock_resp
+            _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+        chat_kwargs = MockClient.return_value.chat.call_args[1]
+        assert "format" in chat_kwargs
+        assert "standardized_name" in str(chat_kwargs["format"])
+
+    def test_passes_system_and_user_messages(self) -> None:
+        raw = _make_raw()
+        mock_resp = _make_ollama_response(_classified_json())
+
+        with patch("src.transformers.llm_classifier.ollama.Client") as MockClient:
+            MockClient.return_value.chat.return_value = mock_resp
+            _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+        messages = MockClient.return_value.chat.call_args[1]["messages"]
+        roles = [m["role"] for m in messages]
+        assert "system" in roles
+        assert "user" in roles
+
+    def test_wraps_connection_error_for_retry(self) -> None:
+        raw = _make_raw()
+
+        with (
+            patch("src.transformers.llm_classifier.ollama.Client") as MockClient,
+            patch("time.sleep"),
+            pytest.raises(ConnectionError, match="Ollama"),
+        ):
+            MockClient.return_value.chat.side_effect = Exception("connection refused")
+            _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+    def test_retries_on_connection_error(self) -> None:
+        raw = _make_raw()
+        content = _classified_json()
+        mock_resp = _make_ollama_response(content)
+
+        with (
+            patch("src.transformers.llm_classifier.ollama.Client") as MockClient,
+            patch("time.sleep"),
+        ):
+            MockClient.return_value.chat.side_effect = [
+                Exception("connection refused"),
+                Exception("connection refused"),
+                mock_resp,
+            ]
+            result = _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+        assert result.standardized_name == "Hotel Beira Mar"
+
+    def test_raises_value_error_on_invalid_json(self) -> None:
+        raw = _make_raw()
+        mock_resp = _make_ollama_response("not valid json at all")
+
+        with (
+            patch("src.transformers.llm_classifier.ollama.Client") as MockClient,
+            pytest.raises(Exception),
+        ):
+            MockClient.return_value.chat.return_value = mock_resp
+            _classify_with_llm(raw, "http://localhost:11434", "llama3.1:8b")
+
+
+# ---------------------------------------------------------------------------
+# _is_duplicate
+# ---------------------------------------------------------------------------
+
+class TestIsDuplicate:
+    def test_returns_none_when_no_duplicate(self) -> None:
+        client = MagicMock()
+        client.rpc.return_value.execute.return_value.data = None
+        assert _is_duplicate(client, "Hotel X", -27.59, -48.54) is None
+
+    def test_returns_uuid_when_duplicate_found(self) -> None:
+        client = MagicMock()
+        client.rpc.return_value.execute.return_value.data = "existing-dim-uuid"
+        result = _is_duplicate(client, "Hotel X", -27.59, -48.54)
+        assert result == "existing-dim-uuid"
+
+    def test_calls_correct_rpc_function(self) -> None:
+        client = MagicMock()
+        client.rpc.return_value.execute.return_value.data = None
+        _is_duplicate(client, "Hotel Teste", -27.5, -48.5)
+        client.rpc.assert_called_once_with(
+            "check_establishment_duplicate",
+            {"p_nome": "Hotel Teste", "p_lat": -27.5, "p_lon": -48.5},
+        )
+
+    def test_returns_none_when_rpc_fails(self) -> None:
+        client = MagicMock()
+        client.rpc.side_effect = Exception("function not found")
+        # Must not raise — graceful degradation
+        assert _is_duplicate(client, "Hotel X", -27.59, -48.54) is None
+
+
+# ---------------------------------------------------------------------------
+# _build_dim_row
+# ---------------------------------------------------------------------------
+
+class TestBuildDimRow:
+    def test_maps_all_standard_fields(self) -> None:
+        raw = _make_raw(
+            phone="+55 48 9999-0000",
+            website="https://hotel.com",
+            opening_hours="Mo-Su 08:00-22:00",
+            address="Rua A, 1",
+            rating=4.5,
+            review_count=100,
+        )
+        classified = _make_classified(
+            standardized_name="Hotel Beira Mar",
+            type=EstablishmentType.HOTEL,
+            subtype="boutique_hotel",
+            suggested_cnae="5510-8/01",
+            estimated_neighborhood="Centro",
+            tags=["wifi", "pool"],
+            confidence=0.95,
+        )
+        row = _build_dim_row(raw, classified)
+
+        assert row["nome"] == "Hotel Beira Mar"
+        assert row["nome_original"] == "Hotel Beira Mar"
+        assert row["tipo"] == "hotel"
+        assert row["subtipo"] == "boutique_hotel"
+        assert row["cnae_codigo"] == "5510-8/01"
+        assert row["bairro"] == "Centro"
+        assert row["telefone"] == "+55 48 9999-0000"
+        assert row["website"] == "https://hotel.com"
+        assert row["horario_funcionamento"] == "Mo-Su 08:00-22:00"
+        assert row["endereco"] == "Rua A, 1"
+        assert row["rating_google"] == pytest.approx(4.5)
+        assert row["total_reviews"] == 100
+        assert row["ativo"] is True
+
+    def test_location_is_wkt_point(self) -> None:
+        raw = _make_raw(latitude=-27.59, longitude=-48.54)
+        row = _build_dim_row(raw, _make_classified())
+        assert row["location"] == "SRID=4326;POINT(-48.54 -27.59)"
+
+    def test_cuisine_split_from_semicolons(self) -> None:
+        raw = _make_raw(cuisine="italian;seafood;brazilian")
+        row = _build_dim_row(raw, _make_classified())
+        assert row["cuisine"] == ["italian", "seafood", "brazilian"]
+
+    def test_cuisine_none_when_not_provided(self) -> None:
+        raw = _make_raw(cuisine=None)
+        row = _build_dim_row(raw, _make_classified())
+        assert row["cuisine"] is None
+
+    def test_source_refs_osm_id_for_overpass(self) -> None:
+        raw = _make_raw(source="overpass", source_id="node/12345")
+        row = _build_dim_row(raw, _make_classified())
+        assert row["source_refs"] == {"osm_id": "node/12345"}
+
+    def test_source_refs_uses_source_name_for_other(self) -> None:
+        raw = _make_raw(source="outscraper", source_id="ChIJ123")
+        row = _build_dim_row(raw, _make_classified())
+        assert row["source_refs"] == {"outscraper": "ChIJ123"}
+
+    def test_tags_llm_contains_classified_tags(self) -> None:
+        classified = _make_classified(tags=["pet_friendly", "parking"], confidence=0.88)
+        row = _build_dim_row(_make_raw(), classified)
+        assert row["tags_llm"]["tags"] == ["pet_friendly", "parking"]
+        assert row["tags_llm"]["confidence"] == pytest.approx(0.88)
+
+
+# ---------------------------------------------------------------------------
+# _insert_dim_record
+# ---------------------------------------------------------------------------
+
+class TestInsertDimRecord:
+    def test_inserts_to_correct_table(self) -> None:
+        client = MagicMock()
+        client.table.return_value.insert.return_value.execute.return_value.data = [{"id": "x"}]
+        row = _build_dim_row(_make_raw(), _make_classified())
+        count = _insert_dim_record(client, row)
+        client.table.assert_called_with("dim_estabelecimentos")
+        assert count == 1
+
+    def test_returns_zero_when_no_data(self) -> None:
+        client = MagicMock()
+        client.table.return_value.insert.return_value.execute.return_value.data = []
+        assert _insert_dim_record(client, {}) == 0
+
+
+# ---------------------------------------------------------------------------
+# _mark_processed
+# ---------------------------------------------------------------------------
+
+class TestMarkProcessed:
+    def test_updates_correct_table(self) -> None:
+        client = MagicMock()
+        _mark_processed(client, ["id-1", "id-2"])
+        client.table.assert_called_with("raw_crawled_data")
+
+    def test_sets_processed_true(self) -> None:
+        client = MagicMock()
+        _mark_processed(client, ["id-1"])
+        update_args = client.table.return_value.update.call_args[0][0]
+        assert update_args == {"processed": True}
+
+    def test_uses_in_filter_with_all_ids(self) -> None:
+        client = MagicMock()
+        _mark_processed(client, ["id-1", "id-2", "id-3"])
+        in_args = client.table.return_value.update.return_value.in_.call_args
+        assert in_args[0][0] == "id"
+        assert set(in_args[0][1]) == {"id-1", "id-2", "id-3"}
+
+    def test_does_nothing_for_empty_list(self) -> None:
+        client = MagicMock()
+        _mark_processed(client, [])
+        client.table.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _log_pipeline
+# ---------------------------------------------------------------------------
+
+class TestLogPipeline:
+    def test_writes_correct_pipeline_name(self) -> None:
+        client = MagicMock()
+        client.table.return_value.insert.return_value.execute.return_value.data = []
+        with patch("src.transformers.llm_classifier.get_supabase_client", return_value=client):
+            _log_pipeline(batch_id="b1", status="running")
+        row = client.table.return_value.insert.call_args[0][0]
+        assert row["pipeline_name"] == "llm_classifier"
+        assert row["status"] == "running"
+
+    def test_includes_duration_ms(self) -> None:
+        client = MagicMock()
+        client.table.return_value.insert.return_value.execute.return_value.data = []
+        started = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        finished = datetime(2024, 1, 1, 10, 0, 2, tzinfo=timezone.utc)
+        with patch("src.transformers.llm_classifier.get_supabase_client", return_value=client):
+            _log_pipeline("b1", "success", started_at=started, finished_at=finished)
+        row = client.table.return_value.insert.call_args[0][0]
+        assert row["duration_ms"] == 2000
+
+    def test_does_not_raise_on_supabase_error(self) -> None:
+        client = MagicMock()
+        client.table.side_effect = Exception("DB down")
+        with patch("src.transformers.llm_classifier.get_supabase_client", return_value=client):
+            _log_pipeline("b1", "running")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# run_classification (integration-style, all I/O mocked)
+# ---------------------------------------------------------------------------
+
+class TestRunClassification:
+    def _patch_settings(self) -> MagicMock:
+        mock = MagicMock()
+        mock.OLLAMA_URL = "http://localhost:11434"
+        mock.OLLAMA_MODEL = "llama3.1:8b"
+        return mock
+
+    def _make_full_client(
+        self,
+        raw_rows: list[dict] | None = None,
+        rpc_data: str | None = None,
+    ) -> MagicMock:
+        """Build a mock Supabase client that handles all table() chains."""
+        client = MagicMock()
+
+        # SELECT from raw_crawled_data
+        select_chain = (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .limit.return_value
+        )
+        select_chain.execute.return_value.data = raw_rows or []
+
+        # INSERT into dim_estabelecimentos
+        client.table.return_value.insert.return_value.execute.return_value.data = [
+            {"id": "dim-1"}
+        ]
+
+        # UPDATE (mark processed)
+        client.table.return_value.update.return_value.in_.return_value.execute.return_value.data = []
+
+        # INSERT into data_pipeline_logs
+        # (reuses the same chain — MagicMock auto-returns)
+
+        # RPC dedup check
+        client.rpc.return_value.execute.return_value.data = rpc_data
+
+        return client
+
+    def test_returns_classified_count(self) -> None:
+        raw_rows = [_make_raw_row("id-1"), _make_raw_row("id-2")]
+        client = self._make_full_client(raw_rows=raw_rows, rpc_data=None)
+        classified_json = _classified_json()
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+        ):
+            MockOllama.return_value.chat.return_value = _make_ollama_response(classified_json)
+            total = run_classification(batch_size=10)
+
+        assert total == 2
+
+    def test_returns_zero_when_no_records(self) -> None:
+        client = self._make_full_client(raw_rows=[])
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+        ):
+            total = run_classification()
+
+        assert total == 0
+
+    def test_skips_duplicate_records(self) -> None:
+        raw_rows = [_make_raw_row("id-dup")]
+        client = self._make_full_client(raw_rows=raw_rows, rpc_data="existing-dim-uuid")
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+        ):
+            total = run_classification()
+            MockOllama.return_value.chat.assert_not_called()
+
+        assert total == 0
+
+    def test_duplicate_records_still_marked_processed(self) -> None:
+        raw_rows = [_make_raw_row("id-dup")]
+        client = self._make_full_client(raw_rows=raw_rows, rpc_data="existing-dim-uuid")
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client"),
+        ):
+            run_classification()
+
+        client.table.return_value.update.assert_called_with({"processed": True})
+
+    def test_skips_records_without_coordinates(self) -> None:
+        payload = _make_raw(latitude=None, longitude=None).model_dump(mode="json")
+        raw_rows = [_make_raw_row("id-nocoord", payload=payload)]
+        client = self._make_full_client(raw_rows=raw_rows)
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+        ):
+            total = run_classification()
+            MockOllama.return_value.chat.assert_not_called()
+
+        assert total == 0
+
+    def test_llm_error_does_not_mark_record_processed(self) -> None:
+        raw_rows = [_make_raw_row("id-llm-fail")]
+        client = self._make_full_client(raw_rows=raw_rows, rpc_data=None)
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+            patch("time.sleep"),
+        ):
+            MockOllama.return_value.chat.side_effect = Exception("connection refused")
+            total = run_classification()
+
+        # Not marked as processed (in_ not called with this id)
+        in_calls = client.table.return_value.update.return_value.in_.call_args_list
+        processed_ids = [c[0][1] for c in in_calls] if in_calls else []
+        flat_ids = [i for sublist in processed_ids for i in sublist]
+        assert "id-llm-fail" not in flat_ids
+        assert total == 0
+
+    def test_invalid_payload_marked_processed_and_skipped(self) -> None:
+        raw_rows = [_make_raw_row("id-bad", payload={"bad": "data"})]
+        client = self._make_full_client(raw_rows=raw_rows)
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+        ):
+            total = run_classification()
+            MockOllama.return_value.chat.assert_not_called()
+
+        assert total == 0
+        client.table.return_value.update.assert_called_with({"processed": True})
+
+    def test_logs_running_then_success(self) -> None:
+        client = self._make_full_client(raw_rows=[])
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+        ):
+            run_classification()
+
+        log_rows = [
+            c[0][0]
+            for c in client.table.return_value.insert.call_args_list
+            if isinstance(c[0][0], dict) and "pipeline_name" in c[0][0]
+        ]
+        statuses = [r["status"] for r in log_rows]
+        assert "running" in statuses
+        # No records → "skipped"
+        assert "skipped" in statuses
+
+    def test_logs_success_when_records_classified(self) -> None:
+        raw_rows = [_make_raw_row("id-ok")]
+        client = self._make_full_client(raw_rows=raw_rows)
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+            patch("src.transformers.llm_classifier.ollama.Client") as MockOllama,
+        ):
+            MockOllama.return_value.chat.return_value = _make_ollama_response(_classified_json())
+            run_classification()
+
+        log_rows = [
+            c[0][0]
+            for c in client.table.return_value.insert.call_args_list
+            if isinstance(c[0][0], dict) and "status" in c[0][0]
+        ]
+        statuses = [r["status"] for r in log_rows]
+        assert "success" in statuses
+
+    def test_default_batch_size_is_used_when_not_specified(self) -> None:
+        client = self._make_full_client(raw_rows=[])
+
+        with (
+            patch("src.transformers.llm_classifier.get_supabase_client", return_value=client),
+            patch("src.transformers.llm_classifier.get_settings", return_value=self._patch_settings()),
+        ):
+            run_classification()
+
+        limit_call = (
+            client.table.return_value
+            .select.return_value
+            .eq.return_value
+            .limit.call_args
+        )
+        assert limit_call[0][0] == _BATCH_SIZE


### PR DESCRIPTION
Closes #3

## Summary

- Implementa `src/transformers/llm_classifier.py` — lê `raw_crawled_data WHERE processed = false` em batches, classifica via Ollama com `ClassifiedEstablishment.model_json_schema()` como `format`, e insere em `dim_estabelecimentos`
- Adiciona `sql/008_classifier_functions.sql` — função `check_establishment_duplicate()` que combina pg_trgm similarity > 0.8 com PostGIS ST_DWithin < 50 m para dedup fuzzy
- Erros LLM não marcam o registro como processado — será retentado no próximo batch
- Insere com `SRID=4326;POINT(lon lat)` para o campo PostGIS `location`
- Pipeline logado em `data_pipeline_logs`

## Test plan

- [x] 42 unit tests em `tests/test_transformers/test_llm_classifier.py` — offline, Ollama e Supabase mockados
- [x] Suite completa: 99/99 passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)